### PR TITLE
fix: Fix note rename detection

### DIFF
--- a/docs/seano-db/v1/ff/c4ecf1ebf740c5894456ed19b1dc15.yaml
+++ b/docs/seano-db/v1/ff/c4ecf1ebf740c5894456ed19b1dc15.yaml
@@ -1,0 +1,33 @@
+---
+risk: medium
+
+tickets:
+- https://github.com/andrewkeller/seano-cli/issues/1
+
+customer-short-loc-hlist-md:
+  en-US:
+  - Fixes:
+    - Improved note rename detection
+
+employee-short-loc-hlist-md:
+  en-US:
+  - Fixed note rename detection
+
+employee-technical-loc-md:
+  en-US: |
+    Seano uses Git history to identify when a note was first added.  This can
+    involve following renames in some cases.  A bug was found where rename
+    detection did not work at all on Windows, due to mismanagement of
+    platform-specific directory separators.
+
+    The bug has been fixed.
+
+    The fix resulted in a unit test failure.  Curiously, the test failure
+    **_matched_** some `TODO`'s in the failing test.  Even more curiously, when
+    updating the test to work like the `TODO`'s said it should, the test started
+    passing.  Most likely, past me knew there was a bug, but couldn't find it,
+    so left some `TODO`'s behind in the tests.
+
+    Consequently, although the original purpose of this change was to fix note
+    rename detection on Windows due to a mismanagement of backslashes, this
+    change inadvertently improved note rename detection on all platforms.

--- a/test/seano_cli_tests/db/git_db_query_test.py
+++ b/test/seano_cli_tests/db/git_db_query_test.py
@@ -506,10 +506,9 @@ parent_versions:
                         'after': [{'name': '1.2.3'}],
                         'notes': [
                             {
-                                # TODO: This note was ONLY released in 1.2.4d1.
                                 'id': 'abc-moved',
-                                'commits': sorted([commit_122, commit_head]),
-                                'releases': ['1.2.2', '1.2.4d1'],
+                                'commits': [commit_head],
+                                'releases': ['1.2.4d1'],
                                 'bird': 'dog',
                             },
                         ],
@@ -535,12 +534,10 @@ parent_versions:
                         'after': [{'name': '1.2.1'}],
                         'notes': [
                             {
-                                # TODO: This note was ONLY released in 1.2.4d1.
-                                # TODO: We're missing the 'foo: bar' note in this release.
-                                'id': 'abc-moved',
-                                'commits': sorted([commit_122, commit_head]),
-                                'releases': ['1.2.2', '1.2.4d1'],
-                                'bird': 'dog',
+                                'id': 'ghi',
+                                'commits': [commit_122],
+                                'releases': ['1.2.2'],
+                                'foo': 'bar',
                             },
                         ],
                     },


### PR DESCRIPTION
Seano uses Git history to identify when a note was first added.  This can involve following renames in some cases.  A bug was found where rename detection did not work at all on Windows, due to mismanagement of platform-specific directory separators.

The bug has been fixed.

The fix resulted in a unit test failure.  Curiously, the test failure **_matched_** some `TODO`'s in the failing test.  Even more curiously, when updating the test to work like the `TODO`'s said it should, the test started passing.  Most likely, past me knew there was a bug, but couldn't find it, so left some `TODO`'s behind in the tests.

Consequently, although the original purpose of this change was to fix note rename detection on Windows due to a mismanagement of backslashes, this change inadvertently improved note rename detection on all platforms.